### PR TITLE
Add search space image

### DIFF
--- a/sessions/week-02-binary-search/week-02-binary-search.md
+++ b/sessions/week-02-binary-search/week-02-binary-search.md
@@ -41,6 +41,7 @@ To begin any binary search implementation, do the following:
 The search space encompasses all possible values that may include the value we’re searching for. For instance, when searching for a target in a sorted array, the search space should cover the array, as the target could be anywhere within it.
 
 This is illustrated in the array below, where `left` and `right` pointers define the search space:
+<img width="521" height="207" alt="search_space" src="https://github.com/user-attachments/assets/f27c8a3f-45c8-49c9-80a0-1399185509f7" />
 
 ---
 


### PR DESCRIPTION
This image was missing from the document. I've recreated it with excalidraw and added it.

Let me know if you'd rather have it in a folder separately and linked here.
<img width="521" height="207" alt="search_space" src="https://github.com/user-attachments/assets/80691976-1658-4c10-a824-85662a5f9a2f" />
